### PR TITLE
Fixed warnings for value types with implicit casts (issue #19)

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
@@ -395,9 +395,18 @@ var f2 = (object)""5""; // NO Allocation
         }
 
         [TestMethod]
-        public void TypeConversionAllocation_ImplicitStringCastOperator()
-        {
-            var sampleProgram = @"
+        public void TypeConversionAllocation_ArgumentWithImplicitStringCastOperator() {
+            const string programWithoutImplicitCastOperator = @"
+                public struct AStruct
+                {
+                    public static void Dump(AStruct astruct)
+                    {
+                        System.Console.WriteLine(astruct);
+                    }
+                }
+            ";
+
+            const string programWithImplicitCastOperator = @"
                 public struct AStruct
                 {
                     public readonly string WrappedString;
@@ -417,21 +426,52 @@ var f2 = (object)""5""; // NO Allocation
                         return astruct.WrappedString;
                     }
                 }
-                public class Program
+            ";
+
+            var analyzer = new TypeConversionAllocationAnalyzer();
+
+            var info0 = ProcessCode(analyzer, programWithoutImplicitCastOperator, ImmutableArray.Create(SyntaxKind.Argument));
+            AssertEx.ContainsDiagnostic(info0.Allocations, id: TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule.Id, line: 6, character: 50);
+
+            var info1 = ProcessCode(analyzer, programWithImplicitCastOperator, ImmutableArray.Create(SyntaxKind.Argument));
+            Assert.AreEqual(0, info1.Allocations.Count);
+        }
+
+
+        [TestMethod]
+        public void TypeConversionAllocation_YieldReturnImplicitStringCastOperator() {
+            const string programWithoutImplicitCastOperator = @"
+                public struct AStruct
                 {
-                    public static void Main()
+                    public System.Collections.Generic.IEnumerator<object> GetEnumerator()
                     {
-                        var astruct = new AStruct(System.Environment.MachineName);
-                        AStruct.Dump(astruct);
+                        yield return this;
                     }
                 }
             ";
+
+            const string programWithImplicitCastOperator = @"
+                public struct AStruct
+                {
+                    public System.Collections.Generic.IEnumerator<string> GetEnumerator()
+                    {
+                        yield return this;
+                    }
+
+                    public static implicit operator string(AStruct astruct)
+                    {
+                        return """";
+                    }
+                }
+            ";
+
             var analyzer = new TypeConversionAllocationAnalyzer();
-            var info = ProcessCode(analyzer, sampleProgram, ImmutableArray.Create(SyntaxKind.Argument));
-            Assert.AreEqual(0, info.Allocations.Count);
-            // currently info.Allocations.Count == 1
-            // with info.Allocations[0] =
-            // (13,50): warning HeapAnalyzerBoxingRule: Value type to reference type conversion causes boxing at call site (here), and unboxing at the callee-site. Consider using generics if applicable
+
+            var info0 = ProcessCode(analyzer, programWithoutImplicitCastOperator, ImmutableArray.Create(SyntaxKind.Argument));
+            AssertEx.ContainsDiagnostic(info0.Allocations, id: TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule.Id, line: 6, character: 38);
+
+            var info1 = ProcessCode(analyzer, programWithImplicitCastOperator, ImmutableArray.Create(SyntaxKind.Argument));
+            Assert.AreEqual(0, info1.Allocations.Count);
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -131,8 +131,8 @@
             {
                 var argumentTypeInfo = semanticModel.GetTypeInfo(argument.Expression, cancellationToken);
                 var argumentConversionInfo = semanticModel.GetConversion(argument.Expression, cancellationToken);
-a                CheckTypeConversion(argumentConversionInfo, reportDiagnostic, argument.Expression.GetLocation(), filePath);
-a                CheckDelegateCreation(argument.Expression, argumentTypeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, argument.Expression.GetLocation(), filePath, cancellationToken);
+                CheckTypeConversion(argumentConversionInfo, reportDiagnostic, argument.Expression.GetLocation(), filePath);
+                CheckDelegateCreation(argument.Expression, argumentTypeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, argument.Expression.GetLocation(), filePath, cancellationToken);
             }
         }
 
@@ -159,8 +159,8 @@ a                CheckDelegateCreation(argument.Expression, argumentTypeInfo, se
             {
                 var assignmentExprTypeInfo = semanticModel.GetTypeInfo(binaryExpression.Right, cancellationToken);
                 var assignmentExprConversionInfo = semanticModel.GetConversion(binaryExpression.Right, cancellationToken);
-a                CheckTypeConversion(assignmentExprConversionInfo, reportDiagnostic, binaryExpression.Right.GetLocation(), filePath);
-a                CheckDelegateCreation(binaryExpression.Right, assignmentExprTypeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, binaryExpression.Right.GetLocation(), filePath, cancellationToken);
+                CheckTypeConversion(assignmentExprConversionInfo, reportDiagnostic, binaryExpression.Right.GetLocation(), filePath);
+                CheckDelegateCreation(binaryExpression.Right, assignmentExprTypeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, binaryExpression.Right.GetLocation(), filePath, cancellationToken);
                 return;
             }
         }
@@ -205,8 +205,8 @@ a                CheckDelegateCreation(binaryExpression.Right, assignmentExprTyp
             {
                 var typeInfo = semanticModel.GetTypeInfo(initializer.Value, cancellationToken);
                 var conversionInfo = semanticModel.GetConversion(initializer.Value, cancellationToken);
-a                CheckTypeConversion(conversionInfo, reportDiagnostic, initializer.Value.GetLocation(), filePath);
-c                CheckDelegateCreation(initializer.Value, typeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, initializer.Value.GetLocation(), filePath, cancellationToken);
+                CheckTypeConversion(conversionInfo, reportDiagnostic, initializer.Value.GetLocation(), filePath);
+                CheckDelegateCreation(initializer.Value, typeInfo, semanticModel, isAssignmentToReadonly, reportDiagnostic, initializer.Value.GetLocation(), filePath, cancellationToken);
             }
         }
 


### PR DESCRIPTION
It seems more appropriate to use the Conversion to check for boxing. Use this for all checks as it is not only applicable when using a value type as argument.

Added unit test for the yield return scenario.