### PR TITLE
Warn for boxing and delegate allocation for => syntax

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
@@ -493,5 +493,73 @@ var f2 = (object)""5""; // NO Allocation
                 Assert.AreEqual(1, info.Allocations.Count(x => x.Id == TypeConversionAllocationAnalyzer.ReadonlyMethodGroupAllocationRule.Id), snippet);
             }
         }
+
+        [TestMethod]
+        public void TypeConversionAllocation_ExpressionBodiedPropertyBoxing_WithBoxing() {
+            const string snippet = @"
+                class Program
+                {
+                    object Obj => 1;
+                }
+            ";
+
+            var analyzer = new TypeConversionAllocationAnalyzer();
+            var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(
+                SyntaxKind.ArrowExpressionClause));
+            AssertEx.ContainsDiagnostic(info.Allocations, id: TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule.Id, line: 4, character: 35);
+        }
+
+        [TestMethod]
+        public void TypeConversionAllocation_ExpressionBodiedPropertyBoxing_WithoutBoxing() {
+            const string snippet = @"
+                class Program
+                {
+                    object Obj => 1.ToString();
+                }
+            ";
+
+            var analyzer = new TypeConversionAllocationAnalyzer();
+            var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(
+                SyntaxKind.ArrowExpressionClause));
+            Assert.AreEqual(0, info.Allocations.Count);
+        }
+
+        [TestMethod]
+        public void TypeConversionAllocation_ExpressionBodiedPropertyDelegate() {
+            const string snippet = @"
+                using System;
+                class Program
+                {
+                    void Function(int i) { } 
+
+                    Action<int> Obj => Function;
+                }
+            ";
+
+            var analyzer = new TypeConversionAllocationAnalyzer();
+            var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(
+                SyntaxKind.ArrowExpressionClause));
+            AssertEx.ContainsDiagnostic(info.Allocations, id: TypeConversionAllocationAnalyzer.MethodGroupAllocationRule.Id, line: 7, character: 40);
+        }
+
+        [TestMethod]
+        [Description("Tests that an explicit delegate creation does not trigger HAA0603. " +
+            "It should be handled by HAA0502.")]
+        public void TypeConversionAllocation_ExpressionBodiedPropertyExplicitDelegate_NoWarning() {
+            const string snippet = @"
+                using System;
+                class Program
+                {
+                    void Function(int i) { } 
+
+                    Action<int> Obj => new Action<int>(Function);
+                }
+            ";
+
+            var analyzer = new TypeConversionAllocationAnalyzer();
+            var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(
+                SyntaxKind.ArrowExpressionClause));
+            Assert.AreEqual(0, info.Allocations.Count);
+        }
     }
 }


### PR DESCRIPTION
This merge request fixes issue #44. 

Following the same pattern as the other implicit allocation checks, we check for the following scenario:

```
 class Program {
    object Obj => 1;
}
```

and also for:
```
 class Program {
    void Foo(int) {}
    Action<int> Obj => Foo;
}
```