### PR TITLE
 Do not report for generated code

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     public static class AssertEx
     {

--- a/ClrHeapAllocationsAnalyzer.Test/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Immutable;
-using ClrHeapAllocationAnalyzer;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     [TestClass]
     public class CallSiteImplicitAllocationAnalyzerTests : AllocationAnalyzerTests

--- a/ClrHeapAllocationsAnalyzer.Test/ClrHeapAllocationsAnalyzer.Test.csproj
+++ b/ClrHeapAllocationsAnalyzer.Test/ClrHeapAllocationsAnalyzer.Test.csproj
@@ -168,6 +168,7 @@
     <Compile Include="DisplayClassAllocationAnalyzerTests.cs" />
     <Compile Include="EnumeratorAllocationAnalyzerTests.cs" />
     <Compile Include="ExplicitAllocationAnalyzerTests.cs" />
+    <Compile Include="IgnoreTests.cs" />
     <Compile Include="StackOverflowAnswerTests.cs" />
     <Compile Include="TypeConversionAllocationAnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ClrHeapAllocationsAnalyzer.Test/ConcatenationAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/ConcatenationAllocationAnalyzerTests.cs
@@ -1,10 +1,9 @@
-﻿using ClrHeapAllocationAnalyzer;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     [TestClass]
     public class ConcatenationAllocationAnalyzerTests : AllocationAnalyzerTests {

--- a/ClrHeapAllocationsAnalyzer.Test/DiagnosticEqualityComparer.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/DiagnosticEqualityComparer.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     internal class DiagnosticEqualityComparer : IEqualityComparer<Diagnostic>
     {

--- a/ClrHeapAllocationsAnalyzer.Test/DisplayClassAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/DisplayClassAllocationAnalyzerTests.cs
@@ -1,12 +1,11 @@
-﻿using ClrHeapAllocationAnalyzer;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     [TestClass]
-    public class DisplayClassAllocationAnalyzerTests: AllocationAnalyzerTests
+    public class DisplayClassAllocationAnalyzerTests : AllocationAnalyzerTests
     {
         [TestMethod]
         public void DisplayClassAllocation_AnonymousMethodExpressionSyntax()

--- a/ClrHeapAllocationsAnalyzer.Test/EnumeratorAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/EnumeratorAllocationAnalyzerTests.cs
@@ -1,9 +1,8 @@
-﻿using ClrHeapAllocationAnalyzer;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     [TestClass]
     public class EnumeratorAllocationAnalyzerTests : AllocationAnalyzerTests

--- a/ClrHeapAllocationsAnalyzer.Test/ExplicitAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/ExplicitAllocationAnalyzerTests.cs
@@ -1,9 +1,8 @@
-﻿using ClrHeapAllocationAnalyzer;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     [TestClass]
     public class ExplicitAllocationAnalyzerTests : AllocationAnalyzerTests

--- a/ClrHeapAllocationsAnalyzer.Test/IgnoreTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/IgnoreTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClrHeapAllocationAnalyzer.Test
+{
+    [TestClass]
+    public class IgnoreTests : AllocationAnalyzerTests
+    {
+        [TestMethod]
+        public void AnalyzeProgram_TakesIgnoredAttributesIntoAccount()
+        {
+            const string sampleProgram =
+                @"using System;
+                
+                [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+                public void CreateString1() {
+                    string str = new string('a', 5);
+                }
+
+                [System.CodeDom.Compiler.GeneratedCodeAttribute(""MyCompiler"", ""1.0.0.3"")]
+                public void CreateString2() {
+                    string str = new string('a', 5);
+                }
+
+                [System.ObsoleteAttribute]
+                public void CreateString3() {
+                    string str = new string('a', 5);
+                }";
+
+            var analyser = new ExplicitAllocationAnalyzer();
+            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression));
+            Assert.AreEqual(1, info.Allocations.Count);
+        }
+
+        [TestMethod]
+        public void AnalyzeProgram_TakesIgnoredFilesIntoAccount()
+        {
+            const string sampleProgram =
+                @"using System;
+                public void CreateString() {
+                    string str = new string('a', 5);
+                }";
+
+            var analyser = new ExplicitAllocationAnalyzer();
+            void Check(int expectedCount, string path)
+            {
+                var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression), filePath: path);
+                Assert.AreEqual(expectedCount, info.Allocations.Count);
+            }
+
+            Check(0, "test.g.cs");
+            Check(0, "test.G.cS");
+            Check(1, "test.cs");
+            Check(1, "test.cpp");
+        }
+    }
+}

--- a/ClrHeapAllocationsAnalyzer.Test/StackOverflowAnswerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/StackOverflowAnswerTests.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Immutable;
-using ClrHeapAllocationAnalyzer;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     /// <summary>
     /// Taken from http://stackoverflow.com/questions/7995606/boxing-occurrence-in-c-sharp

--- a/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using ClrHeapAllocationAnalyzer;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 using System.Linq;
 
-namespace ClrHeapAllocationsAnalyzer.Test
+namespace ClrHeapAllocationAnalyzer.Test
 {
     [TestClass]
     public class TypeConversionAllocationAnalyzerTests : AllocationAnalyzerTests

--- a/ClrHeapAllocationsAnalyzer/AllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/AllocationAnalyzer.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Linq;
+
+namespace ClrHeapAllocationAnalyzer
+{
+    public abstract class AllocationAnalyzer : DiagnosticAnalyzer
+    {
+        protected abstract SyntaxKind[] Expressions { get; }
+
+        protected abstract void AnalyzeNode(SyntaxNodeAnalysisContext context);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyze, Expressions);
+        }
+
+        private void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            if (AllocationRules.IsIgnoredFile(context.Node.SyntaxTree.FilePath))
+            {
+                return;
+            }
+
+            if (context.ContainingSymbol.GetAttributes().Any(AllocationRules.IsIgnoredAttribute))
+            {
+                return;
+            }
+
+            AnalyzeNode(context);
+        }
+    }
+}

--- a/ClrHeapAllocationsAnalyzer/AllocationRules.cs
+++ b/ClrHeapAllocationsAnalyzer/AllocationRules.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+
+namespace ClrHeapAllocationAnalyzer
+{
+    public class AllocationRules
+    {
+        private static readonly HashSet<ValueTuple<string, string>> IgnoredAttributes = new HashSet<(string, string)>
+        {
+            ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"),
+            ("System.CodeDom.Compiler", "GeneratedCodeAttribute")
+        };
+
+        public static bool IsIgnoredFile(string filePath)
+        {
+            return filePath.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsIgnoredAttribute(AttributeData attribute)
+        {
+            return IgnoredAttributes.Contains((attribute.AttributeClass.ContainingNamespace.ToString(), attribute.AttributeClass.Name));
+        }
+    }
+}

--- a/ClrHeapAllocationsAnalyzer/CallSiteImplicitAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/CallSiteImplicitAllocationAnalyzer.cs
@@ -10,22 +10,19 @@ namespace ClrHeapAllocationAnalyzer
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class CallSiteImplicitAllocationAnalyzer : DiagnosticAnalyzer
+    public sealed class CallSiteImplicitAllocationAnalyzer : AllocationAnalyzer
     {
         public static DiagnosticDescriptor ParamsParameterRule = new DiagnosticDescriptor("HAA0101", "Array allocation for params parameter", "This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter", "Performance", DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor ValueTypeNonOverridenCallRule = new DiagnosticDescriptor("HAA0102", "Non-overridden virtual method call on value type", "Non-overridden virtual method call on a value type adds a boxing or constrained instruction", "Performance", DiagnosticSeverity.Warning, true);
 
-        internal static object[] EmptyMessageArgs = { };
-
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ParamsParameterRule, ValueTypeNonOverridenCallRule);
 
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.InvocationExpression);
-        }
+        protected override SyntaxKind[] Expressions => new[] { SyntaxKind.InvocationExpression };
 
-        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private static readonly object[] EmptyMessageArgs = { };
+
+        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             var semanticModel = context.SemanticModel;

--- a/ClrHeapAllocationsAnalyzer/ConcatenationAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/ConcatenationAllocationAnalyzer.cs
@@ -8,20 +8,20 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ConcatenationAllocationAnalyzer : DiagnosticAnalyzer {
+    public sealed class ConcatenationAllocationAnalyzer : AllocationAnalyzer
+    {
         public static DiagnosticDescriptor StringConcatenationAllocationRule = new DiagnosticDescriptor("HAA0201", "Implicit string concatenation allocation", "Considering using StringBuilder", "Performance", DiagnosticSeverity.Warning, true, string.Empty, "http://msdn.microsoft.com/en-us/library/2839d5h5(v=vs.110).aspx");
 
         public static DiagnosticDescriptor ValueTypeToReferenceTypeInAStringConcatenationRule = new DiagnosticDescriptor("HAA0202", "Value type to reference type conversion allocation for string concatenation", "Value type ({0}) is being boxed to a reference type for a string concatenation.", "Performance", DiagnosticSeverity.Warning, true, string.Empty, "http://msdn.microsoft.com/en-us/library/yz2be5wk.aspx");
-
-        internal static object[] EmptyMessageArgs = { };
-
+        
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(StringConcatenationAllocationRule, ValueTypeToReferenceTypeInAStringConcatenationRule);
 
-        public override void Initialize(AnalysisContext context) {
-            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression);
-        }
+        protected override SyntaxKind[] Expressions => new[] { SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression };
 
-        private static void AnalyzeNode(SyntaxNodeAnalysisContext context) {
+        private static readonly object[] EmptyMessageArgs = { };
+        
+        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
             var node = context.Node;
             var semanticModel = context.SemanticModel;
             Action<Diagnostic> reportDiagnostic = context.ReportDiagnostic;

--- a/ClrHeapAllocationsAnalyzer/DisplayClassAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/DisplayClassAllocationAnalyzer.cs
@@ -10,24 +10,21 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class DisplayClassAllocationAnalyzer : DiagnosticAnalyzer
+    public sealed class DisplayClassAllocationAnalyzer : AllocationAnalyzer
     {
         public static DiagnosticDescriptor ClosureDriverRule = new DiagnosticDescriptor("HAA0301", "Closure Allocation Source", "Heap allocation of closure Captures: {0}", "Performance", DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor ClosureCaptureRule = new DiagnosticDescriptor("HAA0302", "Display class allocation to capture closure", "The compiler will emit a class that will hold this as a field to allow capturing of this closure", "Performance", DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor LambaOrAnonymousMethodInGenericMethodRule = new DiagnosticDescriptor("HAA0303", "Lambda or anonymous method in a generic method allocates a delegate instance", "Considering moving this out of the generic method", "Performance", DiagnosticSeverity.Warning, true);
-
-        internal static object[] EmptyMessageArgs = { };
-
+        
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ClosureCaptureRule, ClosureDriverRule, LambaOrAnonymousMethodInGenericMethodRule);
 
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.AnonymousMethodExpression);
-        }
+        protected override SyntaxKind[] Expressions => new[] { SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.AnonymousMethodExpression };
 
-        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private static readonly object[] EmptyMessageArgs = { };
+
+        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             var semanticModel = context.SemanticModel;

--- a/ClrHeapAllocationsAnalyzer/EnumeratorAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/EnumeratorAllocationAnalyzer.cs
@@ -9,27 +9,23 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class EnumeratorAllocationAnalyzer : DiagnosticAnalyzer
+    public sealed class EnumeratorAllocationAnalyzer : AllocationAnalyzer
     {
         public static DiagnosticDescriptor ReferenceTypeEnumeratorRule = new DiagnosticDescriptor("HAA0401", "Possible allocation of reference type enumerator", "Non-ValueType enumerator may result in an heap allocation", "Performance", DiagnosticSeverity.Warning, true);
 
-        internal static object[] EmptyMessageArgs = { };
-
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ReferenceTypeEnumeratorRule);
 
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ForEachStatement, SyntaxKind.InvocationExpression);
-        }
+        protected override SyntaxKind[] Expressions => new[] { SyntaxKind.ForEachStatement, SyntaxKind.InvocationExpression };
 
-        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private static readonly object[] EmptyMessageArgs = { };
+
+        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             var semanticModel = context.SemanticModel;
             Action<Diagnostic> reportDiagnostic = context.ReportDiagnostic;
             var cancellationToken = context.CancellationToken;
             string filePath = node.SyntaxTree.FilePath;
-
             var foreachExpression = node as ForEachStatementSyntax;
             if (foreachExpression != null)
             {

--- a/ClrHeapAllocationsAnalyzer/ExplicitAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/ExplicitAllocationAnalyzer.cs
@@ -8,7 +8,7 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ExplicitAllocationAnalyzer : DiagnosticAnalyzer
+    public sealed class ExplicitAllocationAnalyzer : AllocationAnalyzer
     {
         public static DiagnosticDescriptor NewArrayRule = new DiagnosticDescriptor("HAA0501", "Explicit new array type allocation", "Explicit new array type allocation", "Performance", DiagnosticSeverity.Info, true);
 
@@ -22,28 +22,24 @@
 
         public static DiagnosticDescriptor LetCauseRule = new DiagnosticDescriptor("HAA0506", "Let clause induced allocation", "Let clause induced allocation", "Performance", DiagnosticSeverity.Info, true);
 
-        internal static object[] EmptyMessageArgs = { };
-
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(LetCauseRule, InitializerCreationRule, ImplicitArrayCreationRule, AnonymousNewObjectRule, NewObjectRule, NewArrayRule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override SyntaxKind[] Expressions => new[]
         {
-            var kinds = new[]
-            {
-                SyntaxKind.ObjectCreationExpression,            // Used
-                SyntaxKind.AnonymousObjectCreationExpression,   // Used
-                SyntaxKind.ArrayInitializerExpression,          // Used (this is inside an ImplicitArrayCreationExpression)
-                SyntaxKind.CollectionInitializerExpression,     // Is this used anywhere?
-                SyntaxKind.ComplexElementInitializerExpression, // Is this used anywhere? For what this is see http://source.roslyn.codeplex.com/#Microsoft.CodeAnalysis.CSharp/Compilation/CSharpSemanticModel.cs,80
-                SyntaxKind.ObjectInitializerExpression,         // Used linked to InitializerExpressionSyntax
-                SyntaxKind.ArrayCreationExpression,             // Used
-                SyntaxKind.ImplicitArrayCreationExpression,     // Used (this then contains an ArrayInitializerExpression)
-                SyntaxKind.LetClause                            // Used
-            };
-            context.RegisterSyntaxNodeAction(AnalyzeNode, kinds);
-        }
+            SyntaxKind.ObjectCreationExpression,            // Used
+            SyntaxKind.AnonymousObjectCreationExpression,   // Used
+            SyntaxKind.ArrayInitializerExpression,          // Used (this is inside an ImplicitArrayCreationExpression)
+            SyntaxKind.CollectionInitializerExpression,     // Is this used anywhere?
+            SyntaxKind.ComplexElementInitializerExpression, // Is this used anywhere? For what this is see http://source.roslyn.codeplex.com/#Microsoft.CodeAnalysis.CSharp/Compilation/CSharpSemanticModel.cs,80
+            SyntaxKind.ObjectInitializerExpression,         // Used linked to InitializerExpressionSyntax
+            SyntaxKind.ArrayCreationExpression,             // Used
+            SyntaxKind.ImplicitArrayCreationExpression,     // Used (this then contains an ArrayInitializerExpression)
+            SyntaxKind.LetClause                            // Used
+        };
 
-        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private static readonly object[] EmptyMessageArgs = { };
+
+        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             var semanticModel = context.SemanticModel;

--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -10,7 +10,7 @@
 
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class TypeConversionAllocationAnalyzer : DiagnosticAnalyzer
+    public sealed class TypeConversionAllocationAnalyzer : AllocationAnalyzer
     {
         public static DiagnosticDescriptor ValueTypeToReferenceTypeConversionRule = new DiagnosticDescriptor("HAA0601", "Value type to reference type conversion causing boxing allocation", "Value type to reference type conversion causes boxing at call site (here), and unboxing at the callee-site. Consider using generics if applicable", "Performance", DiagnosticSeverity.Warning, true);
 
@@ -20,31 +20,27 @@
 
         public static DiagnosticDescriptor ReadonlyMethodGroupAllocationRule = new DiagnosticDescriptor("HeapAnalyzerReadonlyMethodGroupAllocationRule", "Delegate allocation from a method group", "This will allocate a delegate instance", "Performance", DiagnosticSeverity.Info, true);
 
-        internal static object[] EmptyMessageArgs = { };
-
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ValueTypeToReferenceTypeConversionRule, DelegateOnStructInstanceRule, MethodGroupAllocationRule, ReadonlyMethodGroupAllocationRule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override SyntaxKind[] Expressions => new[]
         {
-            var kinds = new[]
-            {
-                SyntaxKind.SimpleAssignmentExpression,
-                SyntaxKind.ReturnStatement,
-                SyntaxKind.YieldReturnStatement,
-                SyntaxKind.CastExpression,
-                SyntaxKind.AsExpression,
-                SyntaxKind.CoalesceExpression,
-                SyntaxKind.ConditionalExpression,
-                SyntaxKind.ForEachStatement,
-                SyntaxKind.EqualsValueClause,
-                SyntaxKind.Interpolation,
-                SyntaxKind.Argument,
-                SyntaxKind.ArrowExpressionClause
-            };
-            context.RegisterSyntaxNodeAction(AnalyzeNode, kinds);
-        }
+            SyntaxKind.SimpleAssignmentExpression,
+            SyntaxKind.ReturnStatement,
+            SyntaxKind.YieldReturnStatement,
+            SyntaxKind.CastExpression,
+            SyntaxKind.AsExpression,
+            SyntaxKind.CoalesceExpression,
+            SyntaxKind.ConditionalExpression,
+            SyntaxKind.ForEachStatement,
+            SyntaxKind.EqualsValueClause,
+            SyntaxKind.Argument,
+            SyntaxKind.ArrowExpressionClause,
+            SyntaxKind.Interpolation
+        };
 
-        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private static readonly object[] EmptyMessageArgs = { };
+
+        protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             var semanticModel = context.SemanticModel;


### PR DESCRIPTION
Files: *.g.cs
Attributes: CompilerGeneratedAttribute, GeneratedCodeAttribute

Pulled out code into AllocationAnalyzer that all other analyzers inherit from. Before any other analysis is done, the base class checks if the file/method is ignored.

Some other minor changes:
* Changed namespace in the test project