### PR TITLE
Hot path analysis

### DIFF
--- a/ClrHeapAllocationAnalyzer.Annotations/ClrHeapAllocationAnalyzer.Annotations.csproj
+++ b/ClrHeapAllocationAnalyzer.Annotations/ClrHeapAllocationAnalyzer.Annotations.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{202C0C68-65A5-458C-A0B8-4623465ED579}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ClrHeapAllocationAnalyzer.Annotations</RootNamespace>
+    <AssemblyName>ClrHeapAllocationAnalyzer.Annotations</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PerformanceCriticalAttribute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/ClrHeapAllocationAnalyzer.Annotations/ClrHeapAllocationAnalyzer.Annotations.csproj
+++ b/ClrHeapAllocationAnalyzer.Annotations/ClrHeapAllocationAnalyzer.Annotations.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClrHeapAllocationAnalyzer.Annotations</RootNamespace>
     <AssemblyName>ClrHeapAllocationAnalyzer.Annotations</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ClrHeapAllocationAnalyzer.Annotations/PerformanceCriticalAttribute.cs
+++ b/ClrHeapAllocationAnalyzer.Annotations/PerformanceCriticalAttribute.cs
@@ -9,5 +9,14 @@ namespace Microsoft.Diagnostics
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
     public class PerformanceCriticalAttribute : Attribute
     {
+        public AllocationKind Allocations { get; set; } = AllocationKind.All;
+    }
+
+    [Flags]
+    public enum AllocationKind
+    {
+        Explicit = 1,
+        TheRest = 2,
+        All = Explicit | TheRest
     }
 }

--- a/ClrHeapAllocationAnalyzer.Annotations/PerformanceCriticalAttribute.cs
+++ b/ClrHeapAllocationAnalyzer.Annotations/PerformanceCriticalAttribute.cs
@@ -9,14 +9,5 @@ namespace Microsoft.Diagnostics
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
     public class PerformanceCriticalAttribute : Attribute
     {
-        public AllocationKind Allocations { get; set; } = AllocationKind.All;
-    }
-
-    [Flags]
-    public enum AllocationKind
-    {
-        Explicit = 1,
-        TheRest = 2,
-        All = Explicit | TheRest
     }
 }

--- a/ClrHeapAllocationAnalyzer.Annotations/PerformanceCriticalAttribute.cs
+++ b/ClrHeapAllocationAnalyzer.Annotations/PerformanceCriticalAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics
+{
+    /// <summary>
+    /// Indicates that the marked element is performance critical and should be
+    /// analyzed for heap allocations.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+    public class PerformanceCriticalAttribute : Attribute
+    {
+    }
+}

--- a/ClrHeapAllocationAnalyzer.Annotations/Properties/AssemblyInfo.cs
+++ b/ClrHeapAllocationAnalyzer.Annotations/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClrHeapAllocationAnalyzer.Annotations")]
+[assembly: AssemblyDescription("Provides custom attributes that can be applied to performance critical methods for use in conjuction with the Roslyn CLR Heap Allication Analyzer.")]
+[assembly: AssemblyProduct("ClrHeapAllocationAnalyzer")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ClrHeapAllocationAnalyzer.sln
+++ b/ClrHeapAllocationAnalyzer.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClrHeapAllocationAnalyzer.V
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClrHeapAllocationAnalyzer", "ClrHeapAllocationsAnalyzer\ClrHeapAllocationAnalyzer.csproj", "{EAF46154-6613-4CD6-BE70-9015FF94F9CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClrHeapAllocationAnalyzer.Annotations", "ClrHeapAllocationAnalyzer.Annotations\ClrHeapAllocationAnalyzer.Annotations.csproj", "{202C0C68-65A5-458C-A0B8-4623465ED579}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,8 +29,15 @@ Global
 		{EAF46154-6613-4CD6-BE70-9015FF94F9CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EAF46154-6613-4CD6-BE70-9015FF94F9CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EAF46154-6613-4CD6-BE70-9015FF94F9CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{202C0C68-65A5-458C-A0B8-4623465ED579}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{202C0C68-65A5-458C-A0B8-4623465ED579}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{202C0C68-65A5-458C-A0B8-4623465ED579}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{202C0C68-65A5-458C-A0B8-4623465ED579}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {027507E2-AE88-4B44-BDFF-F6C1A8CE8381}
 	EndGlobalSection
 EndGlobal

--- a/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
@@ -51,6 +51,12 @@ namespace ClrHeapAllocationAnalyzer.Test
         protected Info ProcessCode(DiagnosticAnalyzer analyzer, string sampleProgram,
             ImmutableArray<SyntaxKind> expected, bool allowBuildErrors = false, string filePath = "")
         {
+            return ProcessCode(ImmutableArray.Create(analyzer), sampleProgram, expected, allowBuildErrors, filePath);
+        }
+
+        protected Info ProcessCode(ImmutableArray<DiagnosticAnalyzer> analyzers, string sampleProgram,
+            ImmutableArray<SyntaxKind> expected, bool allowBuildErrors = false, string filePath = "")
+        {
             var options = new CSharpParseOptions(kind: SourceCodeKind.Script);
             var tree = CSharpSyntaxTree.ParseText(sampleProgram, options, filePath);
             var compilation = CSharpCompilation.Create("Test", new[] { tree }, references);
@@ -69,7 +75,7 @@ namespace ClrHeapAllocationAnalyzer.Test
             var matches = GetExpectedDescendants(tree.GetRoot().ChildNodes(), expected);
 
             // Run the code tree through the analyzer and record the allocations it reports
-            var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer));
+            var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
             var allocations = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult().Distinct(DiagnosticEqualityComparer.Instance).ToList();
 
             return new Info

--- a/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
@@ -51,12 +51,6 @@ namespace ClrHeapAllocationAnalyzer.Test
         protected Info ProcessCode(DiagnosticAnalyzer analyzer, string sampleProgram,
             ImmutableArray<SyntaxKind> expected, bool allowBuildErrors = false, string filePath = "")
         {
-            return ProcessCode(ImmutableArray.Create(analyzer), sampleProgram, expected, allowBuildErrors, filePath);
-        }
-
-        protected Info ProcessCode(ImmutableArray<DiagnosticAnalyzer> analyzers, string sampleProgram,
-            ImmutableArray<SyntaxKind> expected, bool allowBuildErrors = false, string filePath = "")
-        {
             var options = new CSharpParseOptions(kind: SourceCodeKind.Script);
             var tree = CSharpSyntaxTree.ParseText(sampleProgram, options, filePath);
             var compilation = CSharpCompilation.Create("Test", new[] { tree }, references);
@@ -75,7 +69,7 @@ namespace ClrHeapAllocationAnalyzer.Test
             var matches = GetExpectedDescendants(tree.GetRoot().ChildNodes(), expected);
 
             // Run the code tree through the analyzer and record the allocations it reports
-            var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
+            var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer));
             var allocations = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult().Distinct(DiagnosticEqualityComparer.Instance).ToList();
 
             return new Info

--- a/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ClrHeapAllocationAnalyzer.Test
@@ -13,6 +14,7 @@ namespace ClrHeapAllocationAnalyzer.Test
     {
         protected static readonly List<MetadataReference> references = new List<MetadataReference>
             {
+                MetadataReference.CreateFromFile(typeof(PerformanceCriticalAttribute).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(int).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),

--- a/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
@@ -7,7 +7,7 @@ namespace ClrHeapAllocationAnalyzer.Test
 {
     public static class AssertEx
     {
-        public static void ContainsDiagnostic(List<Diagnostic> diagnostics, string id, int line, int character)
+        public static void ContainsDiagnostic(List<Diagnostic> diagnostics, string id, int line, int? character = null)
         {
             var msg = string.Format("\r\nExpected {0} at ({1},{2}), i.e. line {1}, at character position {2})\r\nDiagnostics:\r\n{3}\r\n", 
                                     id,  line, character, string.Join("\r\n", diagnostics));
@@ -15,7 +15,7 @@ namespace ClrHeapAllocationAnalyzer.Test
                             diagnostics.Count(d => 
                                 d.Id == id &&
                                 d.Location.GetLineSpan().StartLinePosition.Line + 1 == line &&
-                                d.Location.GetLineSpan().StartLinePosition.Character + 1 == character),
+                                (!character.HasValue || d.Location.GetLineSpan().StartLinePosition.Character + 1 == character.Value)),
                             message: msg);
         }
     }

--- a/ClrHeapAllocationsAnalyzer.Test/ClrHeapAllocationsAnalyzer.Test.csproj
+++ b/ClrHeapAllocationsAnalyzer.Test/ClrHeapAllocationsAnalyzer.Test.csproj
@@ -168,6 +168,7 @@
     <Compile Include="DisplayClassAllocationAnalyzerTests.cs" />
     <Compile Include="EnumeratorAllocationAnalyzerTests.cs" />
     <Compile Include="ExplicitAllocationAnalyzerTests.cs" />
+    <Compile Include="HotPathTests.cs" />
     <Compile Include="IgnoreTests.cs" />
     <Compile Include="StackOverflowAnswerTests.cs" />
     <Compile Include="TypeConversionAllocationAnalyzerTests.cs" />
@@ -187,6 +188,10 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\ClrHeapAllocationAnalyzer.Annotations\ClrHeapAllocationAnalyzer.Annotations.csproj">
+      <Project>{202C0C68-65A5-458C-A0B8-4623465ED579}</Project>
+      <Name>ClrHeapAllocationAnalyzer.Annotations</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ClrHeapAllocationsAnalyzer\ClrHeapAllocationAnalyzer.csproj">
       <Project>{eaf46154-6613-4cd6-be70-9015ff94f9cf}</Project>
       <Name>ClrHeapAllocationAnalyzer</Name>

--- a/ClrHeapAllocationsAnalyzer.Test/HotPathTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/HotPathTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 
@@ -8,7 +9,7 @@ namespace ClrHeapAllocationAnalyzer.Test
     public class HotPathTests : AllocationAnalyzerTests
     {
         [TestMethod]
-        public void AnalyzeProgram_MethodWithAttribute_OtherMethodIgnored()
+        public void AnalyzeProgram_MethodWithDefaultAttribute_OtherMethodIgnored()
         {
             const string sampleProgram =
                 @"using System;
@@ -30,7 +31,7 @@ namespace ClrHeapAllocationAnalyzer.Test
         }
 
         [TestMethod]
-        public void AnalyzeProgram_MethodsWithAttribute_BothAnalyzed()
+        public void AnalyzeProgram_MethodsWithDefaultAttribute_BothAnalyzed()
         {
             const string sampleProgram =
                 @"using System;
@@ -51,6 +52,46 @@ namespace ClrHeapAllocationAnalyzer.Test
             Assert.AreEqual(2, info.Allocations.Count);
             AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 6);
             AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 11);
+        }
+
+        [TestMethod]
+        public void AnalyzeProgram_MethodWithExplicitAttribute_OnlyExplicitWarning()
+        {
+            const string sampleProgram =
+                @"using System;
+                using Microsoft.Diagnostics;
+                
+                [PerformanceCritical(Allocations = AllocationKind.Explicit)]
+                public void CreateString1() {
+                    string s0 = new string('a', 5);
+                    string s1 = ""this will box"" + 1;
+                }";
+
+            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new ExplicitAllocationAnalyzer(), new ConcatenationAllocationAnalyzer());
+            var info = ProcessCode(analyzers, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression, SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
+            Assert.AreEqual(1, info.Allocations.Count);
+            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 6);
+        }
+
+        [TestMethod]
+        public void AnalyzeProgram_MethodWithTwoAttributes_WarnForAll()
+        {
+            const string sampleProgram =
+                @"using System;
+                using Microsoft.Diagnostics;
+                
+                [PerformanceCritical(Allocations = AllocationKind.Explicit)]
+                [PerformanceCritical(Allocations = AllocationKind.All)]
+                public void CreateString1() {
+                    string s0 = new string('a', 5);
+                    string s1 = ""this will box"" + 1;
+                }";
+
+            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new ExplicitAllocationAnalyzer(), new ConcatenationAllocationAnalyzer());
+            var info = ProcessCode(analyzers, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression, SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
+            Assert.AreEqual(2, info.Allocations.Count);
+            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 7);
+            AssertEx.ContainsDiagnostic(info.Allocations, id: ConcatenationAllocationAnalyzer.ValueTypeToReferenceTypeInAStringConcatenationRule.Id, line: 8);
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer.Test/HotPathTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/HotPathTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 
@@ -9,7 +8,7 @@ namespace ClrHeapAllocationAnalyzer.Test
     public class HotPathTests : AllocationAnalyzerTests
     {
         [TestMethod]
-        public void AnalyzeProgram_MethodWithDefaultAttribute_OtherMethodIgnored()
+        public void AnalyzeProgram_MethodWithAttribute_OtherMethodIgnored()
         {
             const string sampleProgram =
                 @"using System;
@@ -31,7 +30,7 @@ namespace ClrHeapAllocationAnalyzer.Test
         }
 
         [TestMethod]
-        public void AnalyzeProgram_MethodsWithDefaultAttribute_BothAnalyzed()
+        public void AnalyzeProgram_MethodsWithAttribute_BothAnalyzed()
         {
             const string sampleProgram =
                 @"using System;
@@ -52,46 +51,6 @@ namespace ClrHeapAllocationAnalyzer.Test
             Assert.AreEqual(2, info.Allocations.Count);
             AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 6);
             AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 11);
-        }
-
-        [TestMethod]
-        public void AnalyzeProgram_MethodWithExplicitAttribute_OnlyExplicitWarning()
-        {
-            const string sampleProgram =
-                @"using System;
-                using Microsoft.Diagnostics;
-                
-                [PerformanceCritical(Allocations = AllocationKind.Explicit)]
-                public void CreateString1() {
-                    string s0 = new string('a', 5);
-                    string s1 = ""this will box"" + 1;
-                }";
-
-            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new ExplicitAllocationAnalyzer(), new ConcatenationAllocationAnalyzer());
-            var info = ProcessCode(analyzers, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression, SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
-            Assert.AreEqual(1, info.Allocations.Count);
-            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 6);
-        }
-
-        [TestMethod]
-        public void AnalyzeProgram_MethodWithTwoAttributes_WarnForAll()
-        {
-            const string sampleProgram =
-                @"using System;
-                using Microsoft.Diagnostics;
-                
-                [PerformanceCritical(Allocations = AllocationKind.Explicit)]
-                [PerformanceCritical(Allocations = AllocationKind.All)]
-                public void CreateString1() {
-                    string s0 = new string('a', 5);
-                    string s1 = ""this will box"" + 1;
-                }";
-
-            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new ExplicitAllocationAnalyzer(), new ConcatenationAllocationAnalyzer());
-            var info = ProcessCode(analyzers, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression, SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
-            Assert.AreEqual(2, info.Allocations.Count);
-            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 7);
-            AssertEx.ContainsDiagnostic(info.Allocations, id: ConcatenationAllocationAnalyzer.ValueTypeToReferenceTypeInAStringConcatenationRule.Id, line: 8);
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer.Test/HotPathTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/HotPathTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Immutable;
+
+namespace ClrHeapAllocationAnalyzer.Test
+{
+    [TestClass]
+    public class HotPathTests : AllocationAnalyzerTests
+    {
+        [TestMethod]
+        public void AnalyzeProgram_MethodWithAttribute_OtherMethodIgnored()
+        {
+            const string sampleProgram =
+                @"using System;
+                using Microsoft.Diagnostics;
+                
+                [PerformanceCritical]
+                public void CreateString1() {
+                    string str = new string('a', 5);
+                }
+
+                public void CreateString2() {
+                    string str = new string('b', 5);
+                }";
+
+            var analyser = new ExplicitAllocationAnalyzer();
+            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression));
+            Assert.AreEqual(1, info.Allocations.Count);
+            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 6);
+        }
+
+        [TestMethod]
+        public void AnalyzeProgram_MethodsWithAttribute_BothAnalyzed()
+        {
+            const string sampleProgram =
+                @"using System;
+                using Microsoft.Diagnostics;
+                
+                [PerformanceCritical]
+                public void CreateString1() {
+                    string str = new string('a', 5);
+                }
+                
+                [PerformanceCritical]
+                public void CreateString2() {
+                    string str = new string('a', 5);
+                }";
+
+            var analyser = new ExplicitAllocationAnalyzer();
+            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.ObjectInitializerExpression));
+            Assert.AreEqual(2, info.Allocations.Count);
+            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 6);
+            AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.NewObjectRule.Id, line: 11);
+        }
+    }
+}

--- a/ClrHeapAllocationsAnalyzer.Vsix/ClrHeapAllocationAnalyzer.Vsix.csproj
+++ b/ClrHeapAllocationsAnalyzer.Vsix/ClrHeapAllocationAnalyzer.Vsix.csproj
@@ -20,6 +20,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -33,7 +34,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClrHeapAllocation</RootNamespace>
     <AssemblyName>ClrHeapAllocation</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/ClrHeapAllocationsAnalyzer/AllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/AllocationAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Linq;
 
@@ -9,6 +10,11 @@ namespace ClrHeapAllocationAnalyzer
         protected abstract SyntaxKind[] Expressions { get; }
 
         protected abstract void AnalyzeNode(SyntaxNodeAnalysisContext context);
+
+        protected virtual void AnalyzeNode(SyntaxNodeAnalysisContext context, EnabledRules rules)
+        {
+            AnalyzeNode(context);
+        }
 
         public override void Initialize(AnalysisContext context)
         {
@@ -27,7 +33,13 @@ namespace ClrHeapAllocationAnalyzer
                 return;
             }
 
-            AnalyzeNode(context);
+            EnabledRules rules = AllocationRules.GetEnabledRules(SupportedDiagnostics, context);
+            if (!rules.AnyEnabled)
+            {
+                return;
+            }
+
+            AnalyzeNode(context, rules);
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer/AllocationRules.cs
+++ b/ClrHeapAllocationsAnalyzer/AllocationRules.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace ClrHeapAllocationAnalyzer
 {
@@ -20,6 +22,12 @@ namespace ClrHeapAllocationAnalyzer
         public static bool IsIgnoredAttribute(AttributeData attribute)
         {
             return IgnoredAttributes.Contains((attribute.AttributeClass.ContainingNamespace.ToString(), attribute.AttributeClass.Name));
+        }
+
+        public static EnabledRules GetEnabledRules(ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
+            SyntaxNodeAnalysisContext context)
+        {
+            return HotPathAnalysis.GetEnabledRules(supportedDiagnostics, context);
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -39,4 +39,8 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ClrHeapAllocationAnalyzer.Annotations\ClrHeapAllocationAnalyzer.Annotations.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -39,8 +39,4 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ClrHeapAllocationAnalyzer.Annotations\ClrHeapAllocationAnalyzer.Annotations.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/ClrHeapAllocationsAnalyzer/EnabledRules.cs
+++ b/ClrHeapAllocationsAnalyzer/EnabledRules.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+namespace ClrHeapAllocationAnalyzer
+{
+    public class EnabledRules
+    {
+        private readonly IReadOnlyDictionary<string, DiagnosticDescriptor> rules;
+
+        public EnabledRules(IReadOnlyDictionary<string, DiagnosticDescriptor> rules)
+        {
+            this.rules = rules;
+        }
+
+        public static readonly EnabledRules None = new EnabledRules(new Dictionary<string, DiagnosticDescriptor>());
+
+        public bool AnyEnabled => rules.Count > 0;
+
+        public bool IsEnabled(string ruleId)
+        {
+            return rules.ContainsKey(ruleId);
+        }
+
+        public DiagnosticDescriptor Get(string ruleId)
+        {
+            if (!rules.ContainsKey(ruleId))
+            {
+                throw new ArgumentException($"Rule '{ruleId}' is not among the enabled rules.", nameof(ruleId));
+            }
+
+            return rules[ruleId];
+        }
+
+        public bool TryGet(string ruleId, out DiagnosticDescriptor descriptor)
+        {
+            return rules.TryGetValue(ruleId, out descriptor);
+        }
+    }
+}

--- a/ClrHeapAllocationsAnalyzer/HotPathAnalysis.cs
+++ b/ClrHeapAllocationsAnalyzer/HotPathAnalysis.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Diagnostics;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -10,29 +8,16 @@ namespace ClrHeapAllocationAnalyzer
 {
     internal class HotPathAnalysis
     {
-        /// <summary>
-        /// Maps rule ids to their respective hot path <see cref="AllocationKind"/>.
-        /// </summary>
-        private static readonly Dictionary<string, AllocationKind> idToKind = new Dictionary<string, AllocationKind> {
-            { "HAA0501", AllocationKind.Explicit },
-            { "HAA0502", AllocationKind.Explicit },
-            { "HAA0503", AllocationKind.Explicit },
-            { "HAA0504", AllocationKind.Explicit },
-            { "HAA0505", AllocationKind.Explicit },
-            { "HAA0506", AllocationKind.Explicit },
-        };
-
         public static EnabledRules GetEnabledRules(ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
           SyntaxNodeAnalysisContext context)
         {
-
-            var hotPathAttributes = context.ContainingSymbol.GetAttributes().Where(IsHotPathAttribute).ToList();
-            if (!ShouldAnalyze(false, hotPathAttributes, context))
+            if (!ShouldAnalyze(false, context))
             {
                 return EnabledRules.None;
             }
 
-            return GetRules(supportedDiagnostics, hotPathAttributes);
+            var allDiagnostrics = supportedDiagnostics.ToDictionary(x => x.Id, x => x);
+            return new EnabledRules(allDiagnostrics);
         }
 
         private static bool IsHotPathAttribute(AttributeData attribute)
@@ -46,10 +31,11 @@ namespace ClrHeapAllocationAnalyzer
         /// analysis be performed?
         /// </summary>
         private static bool ShouldAnalyze(bool onlyReportOnHotPath,
-            IEnumerable<AttributeData> contextHotPathAttributes,
             SyntaxNodeAnalysisContext context)
         {
-            if (contextHotPathAttributes.Any())
+            IEnumerable<AttributeData> hotPathAttributes =
+                context.ContainingSymbol.GetAttributes().Where(IsHotPathAttribute);
+            if (hotPathAttributes.Any())
             {
                 // Always perform analysis regardless of setting when a hot path
                 // is found.
@@ -87,73 +73,6 @@ namespace ClrHeapAllocationAnalyzer
             // The containing type does not have any other member with a hot
             // path attribute -> do analysis.
             return true;
-        }
-        
-        private static EnabledRules GetRules(ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
-            IList<AttributeData> hotPathAttributes)
-        {
-            // Aggregate all attributes.
-            AllocationKind allocationTypes = 0;
-            foreach (var attribute in hotPathAttributes)
-            {
-                PerformanceAttributeData data = ExtractAttributeData(attribute);
-                allocationTypes |= data.Allocations;
-            }
-            
-            // 
-            Dictionary<string, DiagnosticDescriptor> rules = new Dictionary<string, DiagnosticDescriptor>();
-            foreach (var diagnostic in supportedDiagnostics)
-            {
-                if (!idToKind.TryGetValue(diagnostic.Id, out var kind))
-                {
-                    // TODO: Should never happen when all kinds are added.
-                    kind = AllocationKind.TheRest;
-                }
-
-                
-                if (!allocationTypes.HasFlag(kind))
-                {
-                    
-                    continue;
-                }
-
-                rules.Add(diagnostic.Id, diagnostic);
-            }
-            
-
-            return new EnabledRules(rules);
-        }
-
-        private static PerformanceAttributeData ExtractAttributeData(AttributeData attribute)
-        {
-            AllocationKind allocations = AllocationKind.All;
-            if (attribute.NamedArguments.Length == 0)
-            {
-                return new PerformanceAttributeData(allocations);
-            }
-
-            if (attribute.NamedArguments[0].Key == "Allocations")
-            {
-                allocations = (AllocationKind)attribute.NamedArguments[0].Value.Value;
-            } else
-            {
-                throw new ArgumentException($"Unknown named argument {attribute.NamedArguments[0].Key}", nameof(attribute));
-            }
-
-            return new PerformanceAttributeData(allocations);
-        }
-
-        /// <summary>
-        /// Helper struct that represents the data of a <see cref="PerformanceCriticalAttribute"/>.
-        /// </summary>
-        private struct PerformanceAttributeData
-        {
-            public AllocationKind Allocations { get; }
-            
-            public PerformanceAttributeData(AllocationKind allocations = AllocationKind.All)
-            {
-                Allocations = allocations;
-            }
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer/HotPathAnalysis.cs
+++ b/ClrHeapAllocationsAnalyzer/HotPathAnalysis.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace ClrHeapAllocationAnalyzer
+{
+    internal class HotPathAnalysis
+    {
+        public static EnabledRules GetEnabledRules(ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
+          SyntaxNodeAnalysisContext context)
+        {
+            if (!ShouldAnalyze(false, context))
+            {
+                return EnabledRules.None;
+            }
+
+            var allDiagnostrics = supportedDiagnostics.ToDictionary(x => x.Id, x => x);
+            return new EnabledRules(allDiagnostrics);
+        }
+
+        private static bool IsHotPathAttribute(AttributeData attribute)
+        {
+            return attribute.AttributeClass.ContainingNamespace.ToString() == "Microsoft.Diagnostics" &&
+                attribute.AttributeClass.Name == "PerformanceCriticalAttribute";
+        }
+
+        /// <summary>
+        /// Based on the hot path settings and the current context, should an
+        /// analysis be performed?
+        /// </summary>
+        private static bool ShouldAnalyze(bool onlyReportOnHotPath,
+            SyntaxNodeAnalysisContext context)
+        {
+            IEnumerable<AttributeData> hotPathAttributes =
+                context.ContainingSymbol.GetAttributes().Where(IsHotPathAttribute);
+            if (hotPathAttributes.Any())
+            {
+                // Always perform analysis regardless of setting when a hot path
+                // is found.
+                return true;
+            }
+
+            if (onlyReportOnHotPath)
+            {
+                // There was no hot path specified.
+                return false;
+            }
+
+            if (context.ContainingSymbol.ContainingType == null)
+            {
+                // Happens for scripts and snippets.
+                return true;
+            }
+
+            // Check for other members in the type for hot paths. If there is
+            // one, lets not do any analysis for the current context.
+            foreach (ISymbol member in context.ContainingSymbol.ContainingType.GetMembers())
+            {
+                if (ReferenceEquals(context.ContainingSymbol, member))
+                {
+                    // Already checked above.
+                    continue;
+                }
+
+                if (member.GetAttributes().Any(IsHotPathAttribute))
+                {
+                    return false;
+                }
+            }
+
+            // The containing type does not have any other member with a hot
+            // path attribute -> do analysis.
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This PR does not contain a feature-complete hotpath analysis as discussed in #7 and #33. Rather it is a fully working start with a very limited feature set:
* Added the PerformanceCriticalAttribute to its own assembly. This assembly should be released as a separate package so that users only need to reference it rather than the current package
* Members marked with this attribute will enable analysis for all rules within that method with the default severities
* If one member in a class is marked, no unmarked members of that class will be analyzed
* If a class does not have any method with the attribute, analysis is done on every method (default, old behavior)

The PR does not add the ability to specify specific rules to be enabled or change the severity for them but it lays a foundation for it.
