### PR TITLE
Issue #63 - Do not warn on foreach over string

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/EnumeratorAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/EnumeratorAllocationAnalyzerTests.cs
@@ -119,5 +119,16 @@ private IEnumerator<int> GetIEnumeratorViaIEnumerable()
             // Diagnostic: (11,35): warning HeapAnalyzerEnumeratorAllocationRule: Non-ValueType enumerator may result in a heap allocation ***
             AssertEx.ContainsDiagnostic(info.Allocations, id: EnumeratorAllocationAnalyzer.ReferenceTypeEnumeratorRule.Id, line: 11, character: 35);
         }
+
+        [TestMethod]
+        public void EnumeratorAllocation_IterateOverString_NoWarning()
+        {
+            var sampleProgram = "foreach (char c in \"foo\") { }";
+
+            var analyser = new EnumeratorAllocationAnalyzer();
+            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.ForEachStatement));
+
+            Assert.AreEqual(0, info.Allocations.Count);
+        }
     }
 }

--- a/ClrHeapAllocationsAnalyzer/EnumeratorAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/EnumeratorAllocationAnalyzer.cs
@@ -33,6 +33,13 @@
                 if (typeInfo.Type == null)
                     return;
 
+                if (typeInfo.Type.Name == "String" && typeInfo.Type.ContainingNamespace.Name == "System")
+                {
+                    // Special case for System.String which is optmizined by
+                    // the compiler and does not result in an allocation.
+                    return;
+                }
+
                 // Regular way of getting the enumerator
                 ImmutableArray<ISymbol> enumerator = typeInfo.Type.GetMembers("GetEnumerator");
                 if ((enumerator == null || enumerator.Length == 0) && typeInfo.ConvertedType != null)


### PR DESCRIPTION
Fixes https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer/issues/63