### PR TITLE
DiagnosticDescriptor id fix

### DIFF
--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -18,7 +18,7 @@
 
         public static DiagnosticDescriptor MethodGroupAllocationRule = new DiagnosticDescriptor("HAA0603", "Delegate allocation from a method group", "This will allocate a delegate instance", "Performance", DiagnosticSeverity.Warning, true);
 
-        public static DiagnosticDescriptor ReadonlyMethodGroupAllocationRule = new DiagnosticDescriptor("HeapAnalyzerReadonlyMethodGroupAllocationRule", "Delegate allocation from a method group", "This will allocate a delegate instance", "Performance", DiagnosticSeverity.Info, true);
+        public static DiagnosticDescriptor ReadonlyMethodGroupAllocationRule = new DiagnosticDescriptor("HAA0604", "Delegate allocation from a method group", "This will allocate a delegate instance", "Performance", DiagnosticSeverity.Info, true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ValueTypeToReferenceTypeConversionRule, DelegateOnStructInstanceRule, MethodGroupAllocationRule, ReadonlyMethodGroupAllocationRule);
 


### PR DESCRIPTION
ReadonlyMethodGroupAllocationRule is using a name in the DiagnosticDescriptor id field, this corrects it to use an actual id.