### PR TITLE
Prevent reporting HAA0101 when no value for params is provided

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -13,10 +13,10 @@ namespace ClrHeapAllocationAnalyzer.Test
             var sampleProgram =
 @"using System;
 
-Params();
+Params(); //no allocation, because compiler will implicitly substitute Array<int>.Empty
 Params(1, 2);
 Params(new [] { 1, 2}); // explicit, so no warning
-ParamsWithObjects(new [] { 1, 2}); // explicit, but converted to objects, so stil la warning?!
+ParamsWithObjects(new [] { 1, 2}); // explicit, but converted to objects, so still a warning?!
 
 // Only 4 args and above use the params overload of String.Format
 var test = String.Format(""Testing {0}, {1}, {2}, {3}"", 1, ""blah"", 2.0m, 'c');
@@ -32,14 +32,12 @@ public void ParamsWithObjects(params object[] args)
             var analyser = new CallSiteImplicitAllocationAnalyzer();
             var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.InvocationExpression));
 
-            Assert.AreEqual(4, info.Allocations.Count);
-            // Diagnostic: (3,1): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
-            AssertEx.ContainsDiagnostic(info.Allocations, id: CallSiteImplicitAllocationAnalyzer.ParamsParameterRule.Id, line: 3, character: 1);
-            // Diagnostic: (4,1): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
+            Assert.AreEqual(3, info.Allocations.Count, "Should report 3 allocations");
+            // Diagnostic: (4,1): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation
             AssertEx.ContainsDiagnostic(info.Allocations, id: CallSiteImplicitAllocationAnalyzer.ParamsParameterRule.Id, line: 4, character: 1);
-            // Diagnostic: (6,1): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
+            // Diagnostic: (6,1): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation
             AssertEx.ContainsDiagnostic(info.Allocations, id: CallSiteImplicitAllocationAnalyzer.ParamsParameterRule.Id, line: 6, character: 1);
-            // Diagnostic: (9,12): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter
+            // Diagnostic: (9,12): warning HeapAnalyzerImplicitParamsRule: This call site is calling into a function with a 'params' parameter. This results in an array allocation
             AssertEx.ContainsDiagnostic(info.Allocations, id: CallSiteImplicitAllocationAnalyzer.ParamsParameterRule.Id, line: 9, character: 12);
         }
 

--- a/ClrHeapAllocationsAnalyzer/CallSiteImplicitAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/CallSiteImplicitAllocationAnalyzer.cs
@@ -12,7 +12,7 @@ namespace ClrHeapAllocationAnalyzer
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CallSiteImplicitAllocationAnalyzer : AllocationAnalyzer
     {
-        public static DiagnosticDescriptor ParamsParameterRule = new DiagnosticDescriptor("HAA0101", "Array allocation for params parameter", "This call site is calling into a function with a 'params' parameter. This results in an array allocation even if no parameter is passed in for the params parameter", "Performance", DiagnosticSeverity.Warning, true);
+        public static DiagnosticDescriptor ParamsParameterRule = new DiagnosticDescriptor("HAA0101", "Array allocation for params parameter", "This call site is calling into a function with a 'params' parameter. This results in an array allocation", "Performance", DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor ValueTypeNonOverridenCallRule = new DiagnosticDescriptor("HAA0102", "Non-overridden virtual method call on value type", "Non-overridden virtual method call on a value type adds a boxing or constrained instruction", "Performance", DiagnosticSeverity.Warning, true);
 
@@ -54,6 +54,11 @@ namespace ClrHeapAllocationAnalyzer
         private static void CheckParam(InvocationExpressionSyntax invocationExpression, IMethodSymbol methodInfo, SemanticModel semanticModel, Action<Diagnostic> reportDiagnostic, string filePath, CancellationToken cancellationToken)
         {
             var arguments = invocationExpression.ArgumentList.Arguments;
+            if (arguments.Count == methodInfo.Parameters.Length - 1)
+            {
+                return;
+            }
+
             if (arguments.Count != methodInfo.Parameters.Length)
             {
                 reportDiagnostic(Diagnostic.Create(ParamsParameterRule, invocationExpression.GetLocation(), EmptyMessageArgs));


### PR DESCRIPTION
`HAA0101` was incorrectly implemented because the statement `This results in an array allocation even if no parameter is passed in for the params parameter` is not always true. If no parameter is passed then the compiler will insert `Array.Empty<T>()` in the method invocation. This PR fixes this issue.