### PR TITLE
Verify symbol type when reporting HAA0602

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
@@ -11,12 +11,25 @@ namespace ClrHeapAllocationAnalyzer.Test
         {
             var msg = string.Format("\r\nExpected {0} at ({1},{2}), i.e. line {1}, at character position {2})\r\nDiagnostics:\r\n{3}\r\n", 
                                     id,  line, character, string.Join("\r\n", diagnostics));
-            Assert.AreEqual(1, 
-                            diagnostics.Count(d => 
-                                d.Id == id &&
-                                d.Location.GetLineSpan().StartLinePosition.Line + 1 == line &&
-                                d.Location.GetLineSpan().StartLinePosition.Character + 1 == character),
-                            message: msg);
+            var reportingOccurenceCount = CountReportedDiagnostics(diagnostics, id, line, character);
+            Assert.AreEqual(1, reportingOccurenceCount, message: msg);
+        }
+        
+        public static void ContainNoDiagnostic(List<Diagnostic> diagnostics, string id, int line, int character)
+        {
+            var msg = string.Format("\r\nExpected no {0} at ({1},{2}), i.e. line {1}, at character position {2})\r\nDiagnostics:\r\n{3}\r\n", 
+                                    id,  line, character, string.Join("\r\n", diagnostics));
+            var reportingOccurenceCount = CountReportedDiagnostics(diagnostics, id, line, character);
+            Assert.AreEqual(0, reportingOccurenceCount, message: msg);
+        }
+
+        private static int CountReportedDiagnostics(IReadOnlyCollection<Diagnostic> diagnostics, string id, int line, int character)
+        {
+            return diagnostics.Where(d => d.Id == id).Count(d =>
+            {
+                var startLinePosition = d.Location.GetLineSpan().StartLinePosition;
+                return startLinePosition.Line + 1 == line && startLinePosition.Character + 1 == character;
+            });
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AssertEx.cs
@@ -15,7 +15,7 @@ namespace ClrHeapAllocationAnalyzer.Test
             Assert.AreEqual(1, reportingOccurenceCount, message: msg);
         }
         
-        public static void ContainNoDiagnostic(List<Diagnostic> diagnostics, string id, int line, int character)
+        public static void ContainsNoDiagnostic(List<Diagnostic> diagnostics, string id, int line, int character)
         {
             var msg = string.Format("\r\nExpected no {0} at ({1},{2}), i.e. line {1}, at character position {2})\r\nDiagnostics:\r\n{3}\r\n", 
                                     id,  line, character, string.Join("\r\n", diagnostics));

--- a/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
@@ -582,5 +582,28 @@ var f2 = (object)""5""; // NO Allocation
                 SyntaxKind.ArrowExpressionClause));
             Assert.AreEqual(0, info.Allocations.Count);
         }
+
+        [TestMethod]
+        public void TypeConversionAllocation_NoDiagnosticWhenPassingDelegateAsArgument() {
+            const string snippet = @"
+using System;
+struct Foo
+{
+    void Do(Action process)
+    {
+        DoMore(process); // Analyzer triggers warning here, indicating 'process' will be boxed.
+    }
+
+    void DoMore(Action process)
+    {
+        process();
+    }
+}
+            ";
+
+            var analyzer = new TypeConversionAllocationAnalyzer();
+            var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(SyntaxKind.Argument));
+            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 7, 16 );
+        }
     }
 }

--- a/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/TypeConversionAllocationAnalyzerTests.cs
@@ -606,7 +606,7 @@ struct Foo
 
             var analyzer = new TypeConversionAllocationAnalyzer();
             var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(SyntaxKind.Argument));
-            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 7, 16 );
+            AssertEx.ContainsNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 7, 16 );
         }
         
         [TestMethod]
@@ -654,7 +654,7 @@ public struct MyStruct {
 
             var analyzer = new TypeConversionAllocationAnalyzer();
             var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(SyntaxKind.Argument));
-            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 6, 54 );
+            AssertEx.ContainsNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 6, 54 );
         }
         
         [TestMethod]
@@ -678,10 +678,10 @@ public struct MyStruct {
 
             var analyzer = new TypeConversionAllocationAnalyzer();
             var info = ProcessCode(analyzer, snippet, ImmutableArray.Create(SyntaxKind.Argument));
-            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 6, 26 );
-            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 7, 26 );
-            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 8, 26 );
-            AssertEx.ContainNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 9, 26 );
+            AssertEx.ContainsNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 6, 26 );
+            AssertEx.ContainsNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 7, 26 );
+            AssertEx.ContainsNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 8, 26 );
+            AssertEx.ContainsNoDiagnostic(info.Allocations, TypeConversionAllocationAnalyzer.DelegateOnStructInstanceRule.Id, 9, 26 );
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -302,7 +302,7 @@
                 }
 
                 var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
-                if (symbolInfo?.Kind == SymbolKind.Method && symbolInfo?.ContainingType?.IsValueType == true && !insideObjectCreation)
+                if (symbolInfo?.Kind == SymbolKind.Method && symbolInfo?.ContainingType?.IsValueType == true)
                 {
                     reportDiagnostic(Diagnostic.Create(DelegateOnStructInstanceRule, location, EmptyMessageArgs));
                 }

--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -302,7 +302,7 @@
                 }
 
                 var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
-                if (symbolInfo?.ContainingType?.IsValueType == true && !insideObjectCreation)
+                if (symbolInfo?.Kind == SymbolKind.Method && symbolInfo?.ContainingType?.IsValueType == true && !insideObjectCreation)
                 {
                     reportDiagnostic(Diagnostic.Create(DelegateOnStructInstanceRule, location, EmptyMessageArgs));
                 }

--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -302,7 +302,7 @@
                 }
 
                 var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
-                if (symbolInfo?.Kind == SymbolKind.Method && symbolInfo?.ContainingType?.IsValueType == true)
+                if (symbolInfo != null && symbolInfo.Kind == SymbolKind.Method && symbolInfo.IsStatic == false && symbolInfo.ContainingType?.IsValueType == true)
                 {
                     reportDiagnostic(Diagnostic.Create(DelegateOnStructInstanceRule, location, EmptyMessageArgs));
                 }

--- a/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/TypeConversionAllocationAnalyzer.cs
@@ -301,12 +301,23 @@
                     }
                 }
 
-                var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
-                if (symbolInfo != null && symbolInfo.Kind == SymbolKind.Method && symbolInfo.IsStatic == false && symbolInfo.ContainingType?.IsValueType == true)
+                if (IsStructInstanceMethod(node, semanticModel, cancellationToken))
                 {
                     reportDiagnostic(Diagnostic.Create(DelegateOnStructInstanceRule, location, EmptyMessageArgs));
                 }
             }
+        }
+
+        private static bool IsStructInstanceMethod(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var nodeKind = node.Kind();
+            if (nodeKind == SyntaxKind.AnonymousMethodExpression || nodeKind == SyntaxKind.ParenthesizedLambdaExpression)
+            {
+                return false;
+            }
+
+            var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
+            return symbolInfo != null && symbolInfo.Kind == SymbolKind.Method && symbolInfo.IsStatic == false && symbolInfo.ContainingType?.IsValueType == true;
         }
     }
 }


### PR DESCRIPTION
This should fix #66, #67 and partly #18. I've also added additional validation if struct's method is static or not