### PR TITLE
Add missing PrivateAssets for Microsoft.CodeAnalysis dependency

### DIFF
--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.4.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

The lack of `PrivateAssets="all"` results in infecting all the consuming projects with `Microsoft.CodeAnalysis` as a runtime dependency. I found it in the bin directory and I was very surprised 😄 
